### PR TITLE
Add independent Lora load/unload

### DIFF
--- a/dropdown.html
+++ b/dropdown.html
@@ -26,33 +26,44 @@
             </div>
 
             <hr />
-            <div class="flex-container">
+            <div class="flex-container justifySpaceBetween">
                 <h4 data-i18n="Tabby API key">Model Select</h4>
                 <div id="reload_model_list_button" title="Refresh model list" data-i18n="[title]Refresh model list" class="menu_button fa-lg fa-solid fa-repeat"></div>
-            </div>
-
-            <small>Make sure an admin key is set to avoid errors.</small>
-            <div class="flex-container flexFlowColumn">
-                <input id="model_list" name="model_list" class="text_pole flex1 wide100p" placeholder="Model name here" maxlength="100" size="35" value="" autocomplete="off">
-                <input id="draft_model_list" name="draft_model_list" class="text_pole flex1 wide100p" placeholder="Draft model name here" maxlength="100" size="35" value="" autocomplete="off">
-            </div>
-            <div id="loading_progress_container" class="progress_container">
-                <div id="loading_progressbar"></div>
-            </div>
-
-            <div class="flex-container">
-                <input id="load_model_button" class="menu_button" type="submit" value="Load" />
-                <input id="unload_model_button" class="menu_button" type="button" value="Unload" />
 
                 <div id="open_parameter_editor" class="menu_button">
                     <i class="fa-solid fa-pen-to-square"></i>
                     <span>Open Editor</span>
                 </div>
             </div>
-            <hr class="sysHR" />
+
+            <small>Make sure an admin key is set to avoid errors.</small>
+            <div class="flex-container flexFlowColumn">
+                <input id="model_list" name="model_list" class="text_pole flex1 wide100p" placeholder="Model name here" maxlength="100" size="35" value="" autocomplete="off">
+                <input id="draft_model_list" name="draft_model_list" class="text_pole flex1 wide100p" placeholder="Draft model name here" maxlength="100" size="35" value="" autocomplete="off">
+                <div id="loading_progress_container" class="progress_container">
+                    <div id="loading_progressbar"></div>
+                </div>
+                <div class="flex-container">
+                    <input id="load_model_button" class="menu_button" type="submit" value="Load Model(& Draft)" />
+                    <input id="unload_model_button" class="menu_button" type="button" value="Unload Model & Draft" />
+
+                </div>
+                <div class="flex-container flexFlowColumn">
+                    <input id="lora_model_list" name="lora_model_list" class="text_pole flex1 wide100p" placeholder="Lora name here" maxlength="100" size="30" value="" autocomplete="off">
+                    <div id="loraLoadingNotification">Loading Lora.....<i class="fa-solid fa-spinner fa-spin"></i></div>
+                    <div class="flex-container">
+                        <input id="load_lora_button" class="menu_button" type="submit" value="Load Lora" />
+                        <input id="unload_lora_button" class="menu_button" type="button" value="Unload Lora" />
+                    </div>
+                </div>
+
+
+
+
+                <hr class="sysHR" />
+            </div>
+
+
         </div>
-
-
     </div>
-</div>
 </div>

--- a/index.js
+++ b/index.js
@@ -221,7 +221,6 @@ async function onLoadModelClick() {
             let times = 1;
 
             if (draftModelValue) { times++; }
-            if (loraModelValue) { times++; }
 
             console.debug(`TabbyLoader: need to loop ${times} times`);
 

--- a/modelParameters.html
+++ b/modelParameters.html
@@ -33,21 +33,37 @@
                 <input name="rope_alpha" class="text_pole" type="text" />
             </div>
         </div>
-        Draft Model
         <div class="flex-container">
-            <div class="flex1">
-                <label for="rope_scale">
-                    <small data-i18n="Rope Scale">Rope Scale</small>
-                </label>
-                <input name="draft_rope_scale" class="text_pole" type="text" />
+            <div class="flex-container flex1 flexFlowColumn">
+                Draft Model
+                <div class="flex-container">
+                    <div class="flex1">
+                        <label for="rope_scale">
+                            <small data-i18n="Rope Scale">Rope Scale</small>
+                        </label>
+                        <input name="draft_rope_scale" class="text_pole" type="text" />
+                    </div>
+                    <div class="flex1">
+                        <label for="rope_alpha">
+                            <small data-i18n="Rope Alpha">Rope Alpha</small>
+                        </label>
+                        <input name="draft_rope_alpha" class="text_pole" type="text" />
+                    </div>
+                </div>
             </div>
-            <div class="flex1">
-                <label for="rope_alpha">
-                    <small data-i18n="Rope Alpha">Rope Alpha</small>
-                </label>
-                <input name="draft_rope_alpha" class="text_pole" type="text" />
+            <div class="flex-container flex1 flexFlowColumn">
+                Lora
+                <div class="flex-container flex1">
+                    <div class="flex1">
+                        <label for="rope_scale">
+                            <small data-i18n="Rope Scale">Lora Strength</small>
+                        </label>
+                        <input id="lora_scale" name="lora_scale" class="text_pole flex1 wide100p" placeholder="Integer Required" maxlength="100" size="5" min="0" max="10" value="">
+                    </div>
+                </div>
             </div>
         </div>
+
 
         <!-- Container for GPU Split and other options -->
         <div class="flex-container">
@@ -68,7 +84,11 @@
                 </label>
                 <label class="checkbox flex-container">
                     <input type="checkbox" name="eight_bit_cache" />
-                    <span data-i18n="Disable FA2">8-bit Cache</span>
+                    <span data-i18n="8-bit Cache">8-bit Cache</span>
+                </label>
+                <label class="checkbox flex-container">
+                    <input type="checkbox" name="use_cfg" />
+                    <span data-i18n="Use CFG">Use CFG</span>
                 </label>
             </div>
         </div>


### PR DESCRIPTION
- adds param box for Lora scale in editor
- moves editor button to top of model list section
- adds lora model selector, and buttons to independently load/unload loras
- changes toastr responses to include error details

I think my repo wasn't synced to main before I made the commits on my end, so it claims to be "3 commits ahead and 2 commits behind", but I was working from the latest main commit as installed in my ST, so it should be safe to merge all diffs from this PR into main without losing anything.