### PR TITLE
Adds Q6 / Q8 Cache + Fixes Manual ropeAlpha

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,9 @@ let draftModels = [];
 
 const cache_mode = {
     FP16: 0,
-    FP8: 1,
-    Q4: 2,
+    Q4: 1,
+    Q6: 2,
+    Q8: 3,
 }
 
 // From https://stackoverflow.com/questions/9907419/how-to-get-a-key-in-a-javascript-object-by-its-value

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ async function onLoadModelClick() {
         name: modelValue,
         max_seq_len: Number(extensionSettings?.modelParams?.maxSeqLen) || 0,
         rope_scale: Number(extensionSettings?.modelParams?.ropeScale) || null,
-        rope_alpha: Number(extensionSettings?.modelParams?.ropeScale) || null,
+        rope_alpha: Number(extensionSettings?.modelParams?.ropeAlpha) || null,
         no_flash_attention: extensionSettings?.modelParams?.noFlashAttention,
         gpu_split_auto: extensionSettings?.modelParams?.gpuSplitAuto,
         cache_mode: extensionSettings?.modelParams?.cacheMode,

--- a/modelParameters.html
+++ b/modelParameters.html
@@ -81,8 +81,9 @@
                 <small class="justifyCenter">Cache Mode</small>
                 <select name="cache_mode_select" class="margin0">
                     <option value="0">FP16</option>
-                    <option value="1">FP8</option>
-                    <option value="2">Q4</option>
+                    <option value="1">Q4</option>
+                    <option value="2">Q6</option>
+                    <option value="2">Q8</option>
                 </select>
             </div>
         </div>

--- a/modelParameters.html
+++ b/modelParameters.html
@@ -83,7 +83,7 @@
                     <option value="0">FP16</option>
                     <option value="1">Q4</option>
                     <option value="2">Q6</option>
-                    <option value="2">Q8</option>
+                    <option value="3">Q8</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
Allows choosing the new Q6 / Q8 Cache and fixes setting manual ropeAlpha.

ropeAlpha currently bugged because:
rope_scale: Number(extensionSettings?.modelParams?.ropeScale) || null,
rope_alpha: Number(extensionSettings?.modelParams?.ropeScale) || null,